### PR TITLE
refactor: remove validateErrorModal and integrate alertOnlyCancel modal

### DIFF
--- a/frontend/src/components/multistepForm/validateErrorModal.html
+++ b/frontend/src/components/multistepForm/validateErrorModal.html
@@ -1,7 +1,0 @@
-<div class="modal-body">
-  <div class="modal-title"></div>
-  <div class="modal-message"></div>
-  <div class="modal-buttons">
-    <button type="button" class="modal-button button-secondary button-cancel">Cancel</button>
-  </div>
-</div>

--- a/frontend/src/components/multistepForm/validationUtils.ts
+++ b/frontend/src/components/multistepForm/validationUtils.ts
@@ -1,20 +1,21 @@
 import ModalManager from '../ModalManager/ModalManager';
 import { ValidationSchema } from './multistep-form';
 // import { loadModalContent } from '../ModalManager/ModalManager';
-import validateErrorModalContent from './validateErrorModal.html';
+import validateErrorModalContent from '@alerts/alertOnlyCancel.html';
 import { setContent, convertToDom } from '../ModalManager/ModalManager';
+import { modalAlertOnlyCancel } from '@/main';
 
 // Convert the HTML string to a DOM element
-const modalElement = convertToDom(validateErrorModalContent);
+// const modalElement = convertToDom(validateErrorModalContent);
 
 // Set text content of modal elements
-setContent(modalElement, {
-  '.modal-title': 'Validation Error',
-});
+// setContent(modalElement, {
+//   '.modal-title': 'Validation Error',
+// });
 // Add event listeners to the modal buttons
-ModalManager.includeModal('validateErrorModal', {
-  '.button-cancel': () => ModalManager.hide('validateErrorModal'),
-});
+// ModalManager.includeModal('validateErrorModal', {
+//   '.button-cancel': () => ModalManager.hide('validateErrorModal'),
+// });
 
 const numberRegex = /^\d+$/; // Matches only numbers
 
@@ -110,10 +111,11 @@ export function validateFormState(formState: any, validationSchema: ValidationSc
     if (!fieldValidation.result) {
       // alert(fieldValidation.message);
       // console.log(validateErrorModalContent);
-      setContent(modalElement, {
+      setContent(modalAlertOnlyCancel, {
+        '.modal-title': 'Validation Error',
         '.modal-message': fieldValidation.message,
       });
-      ModalManager.show('validateErrorModal', modalElement);
+      ModalManager.show('alertOnlyCancel', modalAlertOnlyCancel);
       return false;
     }
   }

--- a/frontend/src/views/client/projectRequestForm/projectRequestForm.ts
+++ b/frontend/src/views/client/projectRequestForm/projectRequestForm.ts
@@ -49,7 +49,7 @@ class ProjectRequestForm extends View {
       ModalManager.includeModal('projectRequestFormConfirm', {
         '.button-confirm': () => {
           ModalManager.remove('projectRequestFormConfirm');
-          // router.navigateTo('/dashboard');
+          router.navigateTo('/projects');
         },
       });
       ModalManager.show('projectRequestFormConfirm', modalAlertConfirm);

--- a/frontend/src/views/common/projects/Projects.ts
+++ b/frontend/src/views/common/projects/Projects.ts
@@ -40,6 +40,7 @@ export default class ProjectsView extends View {
       this.userId = user.id;
       console.log('user id', this.userId);
       this.projects = await getProjects(this.userId, user.type);
+      console.log('projects', this.projects);
       this.userType = user.type;
       // if (this.projects.length === 0) {
       //   this.projects = [[], []];

--- a/frontend/src/views/common/projects/projectsTable.ts
+++ b/frontend/src/views/common/projects/projectsTable.ts
@@ -50,6 +50,9 @@ export class ProjectTable extends ClickableFilterableTableWithCrumbs {
                 $(q, 'div', 'table-row', {}, (q) => {
                   const values = Object.values(item);
                   values.forEach((element, index) => {
+                    if (element == undefined) {
+                      element = '-';
+                    }
                     const isLastCell = index === values.length - 1;
                     $(
                       q,


### PR DESCRIPTION
- Deleted obsolete validateErrorModal HTML file and updated validationUtils to use alertOnlyCancel modal for error handling.
- Adjusted modal display logic in validationUtils to set content dynamically and show the new alert modal.
- Updated ProjectRequestForm navigation to redirect to '/projects' instead of '/dashboard'.
- Added console log for projects in Projects view to enhance debugging.